### PR TITLE
Allow to pass the whole alloy config as Sensitive

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,7 @@
 #
 # @api private
 class grafana_alloy::config (
-  Optional[String[1]] $config = undef,
+  Optional[Variant[String[1],Sensitive[String[1]]]] $config = undef,
 ) {
   assert_private()
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -4,7 +4,7 @@
 #   The contents of the configuration file, if any
 # @param manage_package_repo Installs the package repositories
 class grafana_alloy (
-  Optional[String[1]] $config = undef,
+  Optional[Variant[String[1], Sensitive[String[1]]]] $config = undef,
   Boolean $manage_package_repo = true,
 ) {
   if $grafana_alloy::manage_package_repo {

--- a/spec/classes/grafana_alloy_spec.rb
+++ b/spec/classes/grafana_alloy_spec.rb
@@ -26,6 +26,13 @@ describe 'grafana_alloy' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_file('/etc/alloy/config.alloy').with_content('my config without managing repo') }
       end
+
+      context 'with sensitive configuration' do
+        let(:params) { super().merge(config: sensitive('my config')) }
+
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_file('/etc/alloy/config.alloy').with_content(sensitive('my config')) }
+      end
     end
   end
 end


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
The alloy configuration contains a lot of sensitive data that might not be wanted in PuppetDB or the logs of the agent.
Passing the configuration contents as Sensitive will allow to exclude this content from both.

#### This Pull Request (PR) fixes the following issues
Fixes !5